### PR TITLE
Use buster image instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim-buster
 LABEL maintainer="Keyko <root@keyko.io>"
 
 ARG VERSION
 
-RUN apk add --no-cache --update \
-    build-base \
-    gcc \
-    libffi-dev \
-    openssl-dev
+RUN apt-get update \
+    && apt-get install gcc -y \
+    && apt-get clean
 
 COPY . /nevermined-pod-config
 WORKDIR /nevermined-pod-config


### PR DESCRIPTION
## Description

Updated docker file to use `slim-buster` instead of `alpine`.
This fixes a dependency problem when installing web3

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation