### PR TITLE
Bump the sdk version to 0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 COPY . /nevermined-pod-config
 WORKDIR /nevermined-pod-config
 
+RUN pip install pip==20.2.4
 RUN pip install .
 
 ENTRYPOINT pod-config --help

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 install_requirements = [
-    "nevermined-sdk-py==0.4.0",
+    "nevermined-sdk-py==0.6.0",
     "web3==5.9.0",
 ]
 


### PR DESCRIPTION
## Description

- Bump python sdk version to v0.6.0
- Fix docker image build by pinning the version of pip

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/internal/issues/109

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation